### PR TITLE
fix: address SonarCloud workflow and title findings

### DIFF
--- a/.github/workflows/deploy-example.yml
+++ b/.github/workflows/deploy-example.yml
@@ -36,14 +36,14 @@ jobs:
           sudo dpkg -i "${{ runner.temp }}/hugo.deb"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Install Node.js dependencies
         run: |
@@ -68,7 +68,7 @@ jobs:
             --destination ../.public
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: .public
 
@@ -86,4 +86,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/render-example-test.yml
+++ b/.github/workflows/render-example-test.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
         with:
           hugo-version: '0.128.0'
           extended: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode | default .Site.Language.Lang | default "en" }}">
-  {{ partial "head.html" . }}
+  <head>
+    <title>{{ partial "page-title.html" . }}</title>
+    {{ partial "head.html" . }}
+  </head>
   <body>
     <a class="skip-link" href="#content">Skip to content</a>
     <div id="root">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,14 +1,9 @@
-<head>
   <meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<style type="text/css">body{font-family:"JetBrains Mono",monospace;}</style>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">body{font-family:"JetBrains Mono",monospace;}</style>
   {{ partial "style-vars.html" . }}
 
-  {{ $title := .Site.Title }}
-  {{ if and .Title (ne .Title .Site.Title) }}
-    {{ $title = printf "%s | %s" .Title .Site.Title }}
-  {{ end }}
-  <title>{{ $title }}</title>
+  {{ $title := partial "page-title.html" . }}
 
   {{ $description := "" }}
   {{ with .Description }}
@@ -75,4 +70,3 @@
   <link rel="mask-icon" href="{{ "safari-pinned-tab.svg" | relURL }}" color="#2b2b2b">
   <meta name="theme-color" content="#ffffff">
   {{ partial "jsonld.html" . }}
-</head>

--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -1,0 +1,5 @@
+{{- $title := .Site.Title -}}
+{{- if and .Title (ne .Title .Site.Title) -}}
+  {{- $title = printf "%s | %s" .Title .Site.Title -}}
+{{- end -}}
+{{- $title -}}


### PR DESCRIPTION
- pin GitHub Actions to commit SHAs
- move page title into the base template for static analysis
- share title generation through a page-title partial
- keep social title metadata using the shared computed title