### PR TITLE
Add projects section and showcase examples

### DIFF
--- a/archetypes/projects.md
+++ b/archetypes/projects.md
@@ -1,0 +1,24 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
+draft: true
+summary: ""
+subtitle: ""
+heroImage: ""
+heroAlt: ""
+year: {{ now.Format "2006" }}
+projectType: ""
+status: ""
+role: ""
+impact: ""
+accent: "#386f64"
+stack: []
+demo: ""
+repo: ""
+---
+
+## Problem
+
+## Approach
+
+## Result

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -23,6 +23,10 @@ menu:
     name: Posts
     url: /posts/
     weight: 3
+  - identifier: projects
+    name: Projects
+    url: /projects/
+    weight: 4
   - identifier: categories
     name: Categories
     url: /categories/

--- a/example-site/config.yaml
+++ b/example-site/config.yaml
@@ -23,6 +23,10 @@ menu:
     name: Posts
     url: /posts/
     weight: 3
+  - identifier: projects
+    name: Projects
+    url: /projects/
+    weight: 4
   - identifier: categories
     name: Categories
     url: /categories/

--- a/example-site/content/posts/theme-showcase/code-and-terminal.md
+++ b/example-site/content/posts/theme-showcase/code-and-terminal.md
@@ -1,0 +1,47 @@
+---
+title: "Theme Showcase: Code and Terminal Output"
+date: 2026-06-09T09:00:00Z
+draft: false
+summary: "A post demonstrating inline code, fenced code blocks, long lines, and syntax highlighting."
+tags: ["code", "syntax highlighting", "hugo"]
+categories: ["theme design"]
+series: ["Theme Showcase"]
+---
+
+Inline code such as `hugo server --disableFastRender` should sit naturally inside a sentence without dominating the surrounding text.
+
+## Shell
+
+```bash
+hugo server --themesDir ../../ --theme smigle-lite --bind 127.0.0.1 --port 1313
+```
+
+Long command lines should scroll horizontally inside the code block instead of breaking the layout.
+
+## JavaScript
+
+```js
+const posts = [
+  { title: "Typography and Flow", tags: ["typography", "writing"] },
+  { title: "Code and Terminal Output", tags: ["code", "syntax-highlighting"] },
+];
+
+const titles = posts
+  .filter((post) => post.tags.includes("code"))
+  .map((post) => post.title);
+
+console.log(titles.join(", "));
+```
+
+## Configuration
+
+```yaml
+params:
+  style:
+    maxWidth: 820px
+    accentColor: "#386f64"
+  toc:
+    enabled: true
+```
+
+The theme uses Chroma classes when Hugo highlighting is configured with `noClasses: false`.

--- a/example-site/content/posts/theme-showcase/edge-cases-and-small-posts.md
+++ b/example-site/content/posts/theme-showcase/edge-cases-and-small-posts.md
@@ -1,0 +1,20 @@
+---
+title: "Theme Showcase: Edge Cases, Short Entries, and Long Titles"
+date: 2026-06-02T09:00:00Z
+draft: false
+summary: "A compact post demonstrating short content, long titles, and sparse page structure."
+tags: ["typography", "accessibility"]
+categories: ["theme design"]
+series: ["Theme Showcase"]
+---
+
+Not every post is long.
+
+Some entries need only a few lines, but they should still render cleanly with the same title, metadata, footer, navigation, and feed behavior as longer articles.
+
+- short paragraph
+- long title
+- small list
+- no images
+
+That is enough for this edge-case example.

--- a/example-site/content/posts/theme-showcase/footnotes-and-references.md
+++ b/example-site/content/posts/theme-showcase/footnotes-and-references.md
@@ -1,0 +1,26 @@
+---
+title: "Theme Showcase: Footnotes and References"
+date: 2026-06-06T09:00:00Z
+draft: false
+summary: "A post demonstrating markdown footnotes and reference-style links."
+tags: ["footnotes", "writing", "metadata"]
+categories: ["writing"]
+series: ["Theme Showcase"]
+---
+
+Footnotes are useful when a note would interrupt the sentence but still belongs on the page.[^purpose]
+
+Reference-style links can also keep source text readable. The theme is built for [Hugo][hugo], a static site generator with strong markdown support.
+
+## Multiple Notes
+
+Footnotes can appear in different sections. They collect at the end of the rendered article, where the theme applies quiet styling and backlink behavior.[^backlinks]
+
+## When to Use Them
+
+Use footnotes when the note supports the article but does not need to be part of the main reading path.
+
+[^purpose]: This is a short footnote showing the default footnote styling.
+[^backlinks]: Hugo adds backlinks so readers can return to the original sentence.
+
+[hugo]: https://gohugo.io/

--- a/example-site/content/posts/theme-showcase/images-and-figures/example.svg
+++ b/example-site/content/posts/theme-showcase/images-and-figures/example.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Page bundle diagram</title>
+  <desc id="desc">A simple diagram showing markdown, local assets, and rendered HTML.</desc>
+  <rect width="1200" height="675" fill="#eef5f2"/>
+  <rect x="94" y="92" width="300" height="420" rx="16" fill="#fff" stroke="#bfd3cc" stroke-width="3"/>
+  <rect x="450" y="92" width="300" height="420" rx="16" fill="#fff" stroke="#bfd3cc" stroke-width="3"/>
+  <rect x="806" y="92" width="300" height="420" rx="16" fill="#fff" stroke="#bfd3cc" stroke-width="3"/>
+  <text x="142" y="160" fill="#386f64" font-family="monospace" font-size="32" font-weight="700">Markdown</text>
+  <text x="514" y="160" fill="#386f64" font-family="monospace" font-size="32" font-weight="700">Assets</text>
+  <text x="870" y="160" fill="#386f64" font-family="monospace" font-size="32" font-weight="700">HTML</text>
+  <rect x="142" y="220" width="204" height="16" rx="8" fill="#8bb7aa"/>
+  <rect x="142" y="264" width="168" height="16" rx="8" fill="#bfd3cc"/>
+  <rect x="142" y="308" width="224" height="16" rx="8" fill="#bfd3cc"/>
+  <rect x="516" y="222" width="168" height="118" rx="12" fill="#e8f1ee" stroke="#bfd3cc" stroke-width="3"/>
+  <circle cx="600" cy="281" r="34" fill="#386f64"/>
+  <rect x="854" y="220" width="204" height="16" rx="8" fill="#8bb7aa"/>
+  <rect x="854" y="264" width="168" height="16" rx="8" fill="#bfd3cc"/>
+  <rect x="854" y="320" width="204" height="90" rx="12" fill="#e8f1ee" stroke="#bfd3cc" stroke-width="3"/>
+  <path d="M396 302h50m304 0h50" fill="none" stroke="#386f64" stroke-width="10" stroke-linecap="round"/>
+  <path d="M430 282l22 20-22 20m354-40l22 20-22 20" fill="none" stroke="#386f64" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/example-site/content/posts/theme-showcase/images-and-figures/index.md
+++ b/example-site/content/posts/theme-showcase/images-and-figures/index.md
@@ -1,0 +1,21 @@
+---
+title: "Theme Showcase: Images and Figures"
+date: 2026-06-08T09:00:00Z
+draft: false
+summary: "A post demonstrating page-bundle images, figure captions, alt text, and image sizing."
+tags: ["images", "accessibility", "hugo"]
+categories: ["theme design"]
+series: ["Theme Showcase"]
+images:
+- posts/theme-showcase/images-and-figures/example.svg
+---
+
+Page bundles keep content and related assets together. This post uses a local SVG stored beside the markdown file.
+
+{{< figure src="example.svg" alt="A diagram of a content page connected to image assets and rendered HTML" caption="A local page-bundle image rendered through the figure shortcode." >}}
+
+Images stay within the content column by default. Captions use quieter text so they support the image without becoming the main content.
+
+## Why Page Bundles Help
+
+When images live beside the page that uses them, moving or deleting content is less error-prone. It also makes the example site easier to inspect because each asset has an obvious owner.

--- a/example-site/content/posts/theme-showcase/long-form-contents.md
+++ b/example-site/content/posts/theme-showcase/long-form-contents.md
@@ -1,0 +1,43 @@
+---
+title: "Theme Showcase: Long Form Article with Contents"
+date: 2026-06-04T09:00:00Z
+draft: false
+summary: "A longer article with enough headings to demonstrate the table of contents partial."
+tags: ["typography", "hugo", "writing"]
+categories: ["writing"]
+series: ["Theme Showcase"]
+---
+
+This article exists to show how the table of contents behaves when a post has enough structure to need one.
+
+## Context
+
+Longer posts benefit from visible structure. A reader should be able to scan the page, understand the sections, and jump to the part they need.
+
+## Setup
+
+The example site enables table of contents support in configuration. Posts with headings can then render a contents block using the theme partial.
+
+### Content Shape
+
+A good long-form page usually has a small introduction, several clear sections, and a conclusion that closes the loop.
+
+### Heading Depth
+
+Third-level headings are useful for subsections, but they should not create a maze. Keep the hierarchy shallow unless the subject truly needs depth.
+
+## Examples
+
+This section creates another top-level entry. The content itself is intentionally simple; the structure is the thing being demonstrated.
+
+### Example One
+
+This subsection uses a short paragraph so the heading remains easy to evaluate.
+
+### Example Two
+
+This subsection gives the contents list another target without adding unrelated complexity.
+
+## Conclusion
+
+The table of contents should help readers navigate without making short posts feel heavy.

--- a/example-site/content/posts/theme-showcase/metadata-and-taxonomies.md
+++ b/example-site/content/posts/theme-showcase/metadata-and-taxonomies.md
@@ -1,0 +1,31 @@
+---
+title: "Theme Showcase: Metadata, Tags, Categories, and Series"
+date: 2026-06-03T09:00:00Z
+draft: false
+summary: "A post demonstrating front matter metadata and taxonomy links."
+tags: ["metadata", "hugo", "static sites"]
+categories: ["publishing workflow"]
+series: ["Theme Showcase"]
+---
+
+This post demonstrates ordinary front matter metadata. The theme can display dates, categories, tags, and series links near the title depending on configuration.
+
+## Front Matter
+
+```yaml
+title: "Theme Showcase: Metadata, Tags, Categories, and Series"
+date: 2026-06-03T09:00:00Z
+draft: false
+summary: "A post demonstrating front matter metadata and taxonomy links."
+tags: ["metadata", "hugo", "static sites"]
+categories: ["publishing workflow"]
+series: ["Theme Showcase"]
+```
+
+## Why It Matters
+
+Metadata improves navigation and feeds without requiring a custom database. For small sites, markdown plus front matter is often enough.
+
+## Taxonomy Pages
+
+The example site includes tag, category, and series pages so these relationships can be inspected directly.

--- a/example-site/content/posts/theme-showcase/shortcodes-in-practice.md
+++ b/example-site/content/posts/theme-showcase/shortcodes-in-practice.md
@@ -1,0 +1,27 @@
+---
+title: "Theme Showcase: Shortcodes in Practice"
+date: 2026-06-07T09:00:00Z
+draft: false
+summary: "A post demonstrating the bundled aside, details, and external link shortcodes."
+tags: ["hugo", "static sites", "accessibility"]
+categories: ["theme design"]
+series: ["Theme Showcase"]
+---
+
+Shortcodes give authors a small set of structured elements without requiring custom HTML in every article.
+
+{{< aside title="Author note" >}}
+The aside shortcode is useful for related context, cautions, or editorial notes that should stand apart from the main paragraph flow.
+{{< /aside >}}
+
+The theme also includes a details shortcode for optional information.
+
+{{< details summary="What belongs in a details block?" >}}
+Use details for supporting material that is useful but not essential on the first read. Examples include setup notes, references, definitions, or longer explanations.
+{{< /details >}}
+
+External links can be written with explicit text and safe attributes. For example, see {{< external-link href="https://gohugo.io/" text="the Hugo website" >}}.
+
+## Plain Markdown Still Works
+
+Shortcodes should complement ordinary markdown rather than replace it. Most posts should still be mostly headings, paragraphs, lists, and links.

--- a/example-site/content/posts/theme-showcase/tables-and-structured-data.md
+++ b/example-site/content/posts/theme-showcase/tables-and-structured-data.md
@@ -1,0 +1,27 @@
+---
+title: "Theme Showcase: Tables and Structured Data"
+date: 2026-06-05T09:00:00Z
+draft: false
+summary: "A post demonstrating markdown tables, wide content, and compact comparison data."
+tags: ["metadata", "typography", "accessibility"]
+categories: ["theme design"]
+series: ["Theme Showcase"]
+---
+
+Tables are useful when the reader needs to compare compact values. The theme keeps table borders visible and allows horizontal scrolling when content is too wide.
+
+| Feature | Example setting | Why it matters |
+| --- | --- | --- |
+| Accent color | `params.style.accentColor` | Controls focus states and small visual accents. |
+| Max width | `params.style.maxWidth` | Keeps long-form reading comfortable. |
+| Table of contents | `params.toc.enabled` | Helps longer posts expose their structure. |
+| Search | `params.search.enabled` | Adds local search for larger example sites. |
+
+## Longer Cells
+
+| Scenario | Notes |
+| --- | --- |
+| A compact personal site | The defaults keep setup small while still supporting posts, projects, taxonomies, search, and feeds. |
+| A documentation-style site | The same typography, code blocks, headings, and table treatment can support longer technical writing. |
+
+Tables should not replace prose, but they are useful for direct comparison.

--- a/example-site/content/posts/theme-showcase/typography-and-flow.md
+++ b/example-site/content/posts/theme-showcase/typography-and-flow.md
@@ -1,0 +1,41 @@
+---
+title: "Theme Showcase: Typography and Flow"
+date: 2026-06-10T09:00:00Z
+draft: false
+summary: "A post demonstrating headings, paragraphs, lists, blockquotes, and the default reading rhythm."
+tags: ["typography", "writing", "accessibility"]
+categories: ["theme design"]
+series: ["Theme Showcase"]
+---
+
+Good typography is mostly ordinary text handled consistently. This post demonstrates the default rhythm for headings, paragraphs, lists, and quotations.
+
+## Section Headings
+
+Headings should create useful structure without forcing a page to feel over-designed. A second-level heading introduces a major topic, and lower headings can break up longer sections.
+
+### A Smaller Heading
+
+This paragraph follows a third-level heading. The theme keeps the text column compact and predictable so pages remain comfortable even when the content is mostly prose.
+
+## Lists
+
+Unordered lists work well for related ideas:
+
+- readable line length
+- visible hierarchy
+- modest vertical spacing
+- default browser semantics
+
+Ordered lists are useful for processes:
+
+1. Write the content.
+2. Add front matter.
+3. Build the site.
+4. Review the output.
+
+## Blockquotes
+
+> A minimal theme should still provide enough structure for readers to scan, pause, and return to the text without losing their place.
+
+The quote above uses the theme's accent color while keeping the page quiet.

--- a/example-site/content/projects/_index.md
+++ b/example-site/content/projects/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Projects"
+subtitle: "A landing page for selected builds, prototypes, and finished work."
+draft: false
+summary: "A project showcase landing page for Smigle Lite's example site."
+---

--- a/example-site/content/projects/atlas-pantry/hero.svg
+++ b/example-site/content/projects/atlas-pantry/hero.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Atlas Pantry preview</title>
+  <desc id="desc">A recipe and pantry planning dashboard with stock cards and a shopping list.</desc>
+  <rect width="1200" height="675" fill="#ecf5f1"/>
+  <rect x="92" y="82" width="1016" height="511" rx="18" fill="#ffffff" stroke="#c5d8d0" stroke-width="3"/>
+  <rect x="92" y="82" width="1016" height="74" rx="18" fill="#386f64"/>
+  <text x="136" y="130" fill="#ffffff" font-family="monospace" font-size="34" font-weight="700">Atlas Pantry</text>
+  <rect x="136" y="204" width="276" height="148" rx="12" fill="#e4f0eb" stroke="#bad0c8" stroke-width="3"/>
+  <text x="164" y="250" fill="#274b44" font-family="monospace" font-size="25" font-weight="700">Staples</text>
+  <rect x="164" y="278" width="190" height="14" rx="7" fill="#386f64"/>
+  <rect x="164" y="309" width="132" height="14" rx="7" fill="#8bb7aa"/>
+  <rect x="462" y="204" width="276" height="148" rx="12" fill="#f8fbf9" stroke="#bad0c8" stroke-width="3"/>
+  <text x="490" y="250" fill="#274b44" font-family="monospace" font-size="25" font-weight="700">Tonight</text>
+  <rect x="490" y="278" width="204" height="14" rx="7" fill="#386f64"/>
+  <rect x="490" y="309" width="156" height="14" rx="7" fill="#8bb7aa"/>
+  <rect x="788" y="204" width="276" height="148" rx="12" fill="#fffaf0" stroke="#d9c793" stroke-width="3"/>
+  <text x="816" y="250" fill="#564822" font-family="monospace" font-size="25" font-weight="700">Buy Next</text>
+  <rect x="816" y="278" width="172" height="14" rx="7" fill="#b58e36"/>
+  <rect x="816" y="309" width="118" height="14" rx="7" fill="#d4ba70"/>
+  <rect x="136" y="398" width="928" height="118" rx="12" fill="#f7faf8" stroke="#d7e4df" stroke-width="3"/>
+  <rect x="164" y="430" width="650" height="16" rx="8" fill="#8bb7aa"/>
+  <rect x="164" y="468" width="490" height="16" rx="8" fill="#c5d8d0"/>
+  <circle cx="978" cy="457" r="38" fill="#386f64"/>
+  <path d="M960 459l13 13 28-34" fill="none" stroke="#fff" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/example-site/content/projects/atlas-pantry/index.md
+++ b/example-site/content/projects/atlas-pantry/index.md
@@ -1,0 +1,33 @@
+---
+title: "Atlas Pantry"
+date: 2026-02-12T09:00:00Z
+draft: false
+weight: 10
+summary: "An offline recipe and stock planner that helps shared kitchens avoid duplicate shopping and forgotten staples."
+subtitle: "An offline recipe and stock planner for shared kitchens."
+heroImage: "hero.svg"
+heroAlt: "Dashboard preview for Atlas Pantry showing pantry stock and recipe planning cards."
+year: 2026
+projectType: "Offline tool"
+status: "Prototype"
+role: "Product design"
+impact: "Shared kitchen planning"
+accent: "#386f64"
+stack: ["Hugo", "SQLite", "Service workers"]
+demo: "https://example.org/projects/atlas-pantry"
+repo: "https://example.org/repos/atlas-pantry"
+---
+
+## Problem
+
+Small shared kitchens often keep recipes, stock counts, and shopping lists in different places. That makes duplicate purchases common and leaves staples buried at the back of the cupboard.
+
+## Approach
+
+Atlas Pantry uses a local-first catalogue that links each recipe to required ingredients, current stock, and a simple shopping queue. It works offline first, then syncs when a connection is available.[^local-first]
+
+## Result
+
+The prototype makes stock gaps visible before a cooking session starts. It also gives coordinators a quick way to see which recipes are realistic with the ingredients already on hand.
+
+[^local-first]: The first prototype stored kitchen records locally so it could still be used in a basement kitchen with unreliable wireless coverage.

--- a/example-site/content/projects/beacon-desk/hero.svg
+++ b/example-site/content/projects/beacon-desk/hero.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Beacon Desk preview</title>
+  <desc id="desc">A support triage board with priority lanes and repair tickets.</desc>
+  <rect width="1200" height="675" fill="#f1eef8"/>
+  <rect x="86" y="78" width="1028" height="520" rx="18" fill="#ffffff" stroke="#d1c9e3" stroke-width="3"/>
+  <text x="132" y="132" fill="#403567" font-family="monospace" font-size="36" font-weight="700">Beacon Desk</text>
+  <rect x="132" y="178" width="280" height="354" rx="14" fill="#fbf9ff" stroke="#d1c9e3" stroke-width="3"/>
+  <rect x="460" y="178" width="280" height="354" rx="14" fill="#fbf9ff" stroke="#d1c9e3" stroke-width="3"/>
+  <rect x="788" y="178" width="280" height="354" rx="14" fill="#fbf9ff" stroke="#d1c9e3" stroke-width="3"/>
+  <text x="164" y="230" fill="#6b5b95" font-family="monospace" font-size="24" font-weight="700">Urgent</text>
+  <text x="492" y="230" fill="#6b5b95" font-family="monospace" font-size="24" font-weight="700">Scheduled</text>
+  <text x="820" y="230" fill="#6b5b95" font-family="monospace" font-size="24" font-weight="700">Done</text>
+  <rect x="164" y="266" width="216" height="72" rx="9" fill="#eee8fb"/>
+  <rect x="164" y="360" width="216" height="72" rx="9" fill="#eee8fb"/>
+  <rect x="492" y="266" width="216" height="72" rx="9" fill="#eee8fb"/>
+  <rect x="492" y="360" width="216" height="72" rx="9" fill="#eee8fb"/>
+  <rect x="820" y="266" width="216" height="72" rx="9" fill="#e6f2e8"/>
+  <rect x="820" y="360" width="216" height="72" rx="9" fill="#e6f2e8"/>
+  <rect x="190" y="292" width="150" height="11" rx="6" fill="#6b5b95"/>
+  <rect x="190" y="318" width="112" height="11" rx="6" fill="#aa9bc9"/>
+  <rect x="518" y="292" width="145" height="11" rx="6" fill="#6b5b95"/>
+  <rect x="518" y="318" width="118" height="11" rx="6" fill="#aa9bc9"/>
+  <rect x="846" y="292" width="135" height="11" rx="6" fill="#4f8a58"/>
+  <rect x="846" y="318" width="104" height="11" rx="6" fill="#97bd9d"/>
+</svg>

--- a/example-site/content/projects/beacon-desk/index.md
+++ b/example-site/content/projects/beacon-desk/index.md
@@ -1,0 +1,31 @@
+---
+title: "Beacon Desk"
+date: 2025-11-03T09:00:00Z
+draft: false
+weight: 20
+summary: "A triage board for field support teams that turns incoming reports into clear, priority-ranked repair work."
+subtitle: "A triage board for field support and repair teams."
+heroImage: "hero.svg"
+heroAlt: "Dashboard preview for Beacon Desk showing repair tickets grouped by priority."
+year: 2025
+projectType: "Operations app"
+status: "Pilot"
+role: "Frontend build"
+impact: "Faster repair triage"
+accent: "#6b5b95"
+stack: ["Hugo", "Alpine.js", "CSV"]
+demo: "https://example.org/projects/beacon-desk"
+repo: "https://example.org/repos/beacon-desk"
+---
+
+## Problem
+
+Field reports arrived through email, calls, and spreadsheets. The repair team needed a single view that could show urgency without requiring a full ticketing platform.
+
+## Approach
+
+Beacon Desk keeps the source data simple: a versioned CSV file powers grouped queues for severity, location, and owner. The interface favors scan speed, short labels, and predictable keyboard navigation.
+
+## Result
+
+The pilot reduced daily planning meetings by giving the team a shared shortlist before anyone opened their inbox.

--- a/example-site/content/projects/canopy-notes/hero.svg
+++ b/example-site/content/projects/canopy-notes/hero.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Canopy Notes preview</title>
+  <desc id="desc">A field notebook interface with tree observations and a simple map.</desc>
+  <rect width="1200" height="675" fill="#eef7ee"/>
+  <rect x="84" y="72" width="1032" height="532" rx="18" fill="#ffffff" stroke="#c8ddc9" stroke-width="3"/>
+  <text x="132" y="132" fill="#2f6532" font-family="monospace" font-size="36" font-weight="700">Canopy Notes</text>
+  <rect x="132" y="178" width="430" height="360" rx="14" fill="#f7fbf7" stroke="#c8ddc9" stroke-width="3"/>
+  <text x="166" y="230" fill="#3f7d42" font-family="monospace" font-size="24" font-weight="700">Observation</text>
+  <rect x="166" y="264" width="324" height="14" rx="7" fill="#3f7d42"/>
+  <rect x="166" y="302" width="260" height="14" rx="7" fill="#91bd94"/>
+  <rect x="166" y="340" width="300" height="14" rx="7" fill="#c8ddc9"/>
+  <rect x="166" y="406" width="152" height="38" rx="19" fill="#e3f0e4" stroke="#91bd94" stroke-width="3"/>
+  <text x="192" y="433" fill="#2f6532" font-family="monospace" font-size="18">Healthy</text>
+  <rect x="610" y="178" width="458" height="360" rx="14" fill="#e9f2ec" stroke="#c8ddc9" stroke-width="3"/>
+  <path d="M660 470c82-78 132-218 256-250 58-15 112 12 126 74" fill="none" stroke="#8eb493" stroke-width="14" stroke-linecap="round"/>
+  <circle cx="728" cy="418" r="22" fill="#3f7d42"/>
+  <circle cx="910" cy="266" r="22" fill="#3f7d42"/>
+  <circle cx="1010" cy="338" r="22" fill="#3f7d42"/>
+  <rect x="650" y="206" width="96" height="12" rx="6" fill="#91bd94"/>
+  <rect x="650" y="232" width="144" height="12" rx="6" fill="#c8ddc9"/>
+</svg>

--- a/example-site/content/projects/canopy-notes/index.md
+++ b/example-site/content/projects/canopy-notes/index.md
@@ -1,0 +1,31 @@
+---
+title: "Canopy Notes"
+date: 2025-07-21T09:00:00Z
+draft: false
+weight: 30
+summary: "A field notebook for urban tree surveys that keeps observations tidy, searchable, and easy to publish."
+subtitle: "A publishable field notebook for urban tree surveys."
+heroImage: "hero.svg"
+heroAlt: "Notebook preview for Canopy Notes showing tree observations and a small map panel."
+year: 2025
+projectType: "Publishing system"
+status: "Live"
+role: "Content model"
+impact: "Survey notes to maps"
+accent: "#3f7d42"
+stack: ["Hugo", "Markdown", "GeoJSON"]
+demo: "https://example.org/projects/canopy-notes"
+repo: "https://example.org/repos/canopy-notes"
+---
+
+## Problem
+
+Volunteer survey notes were easy to collect but hard to review. Photos, species names, coordinates, and follow-up tasks drifted apart after each walk.
+
+## Approach
+
+Canopy Notes stores each observation as a page bundle with front matter for species, condition, and location. A small build step emits a GeoJSON index for mapping while the site remains readable without JavaScript.
+
+## Result
+
+Survey teams can now publish a public record and keep a maintainable private archive from the same source files.

--- a/example-site/content/projects/harbor-watch/hero.svg
+++ b/example-site/content/projects/harbor-watch/hero.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Harbor Watch preview</title>
+  <desc id="desc">A marina operations digest with tide, wind, and maintenance panels.</desc>
+  <rect width="1200" height="675" fill="#edf5fa"/>
+  <rect x="86" y="78" width="1028" height="520" rx="18" fill="#ffffff" stroke="#c1d6e3" stroke-width="3"/>
+  <text x="132" y="132" fill="#275b7d" font-family="monospace" font-size="36" font-weight="700">Harbor Watch</text>
+  <rect x="132" y="180" width="292" height="154" rx="14" fill="#e8f2f8" stroke="#b9d4e4" stroke-width="3"/>
+  <text x="166" y="232" fill="#2f6f98" font-family="monospace" font-size="25" font-weight="700">Tide</text>
+  <path d="M166 286c35-38 70 38 105 0s70 38 105 0" fill="none" stroke="#2f6f98" stroke-width="10" stroke-linecap="round"/>
+  <rect x="454" y="180" width="292" height="154" rx="14" fill="#f8fbfd" stroke="#b9d4e4" stroke-width="3"/>
+  <text x="488" y="232" fill="#2f6f98" font-family="monospace" font-size="25" font-weight="700">Wind</text>
+  <path d="M488 286h174m-76-38h112m-132 76h146" stroke="#2f6f98" stroke-width="11" stroke-linecap="round"/>
+  <rect x="776" y="180" width="292" height="154" rx="14" fill="#f6faf7" stroke="#b9d4e4" stroke-width="3"/>
+  <text x="810" y="232" fill="#2f6f98" font-family="monospace" font-size="25" font-weight="700">Checks</text>
+  <path d="M812 282l28 28 66-78" fill="none" stroke="#4f8f5a" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="132" y="388" width="936" height="112" rx="14" fill="#f7fbfd" stroke="#c1d6e3" stroke-width="3"/>
+  <rect x="166" y="428" width="660" height="14" rx="7" fill="#79a9c6"/>
+  <rect x="166" y="466" width="470" height="14" rx="7" fill="#c1d6e3"/>
+</svg>

--- a/example-site/content/projects/harbor-watch/index.md
+++ b/example-site/content/projects/harbor-watch/index.md
@@ -1,0 +1,31 @@
+---
+title: "Harbor Watch"
+date: 2024-10-08T09:00:00Z
+draft: false
+weight: 40
+summary: "A calm sensor digest for small marinas, focused on tide windows, wind alerts, and maintenance checks."
+subtitle: "A calm sensor digest for small marina operations."
+heroImage: "hero.svg"
+heroAlt: "Dashboard preview for Harbor Watch showing tide, wind, and maintenance panels."
+year: 2024
+projectType: "Sensor dashboard"
+status: "Case study"
+role: "Dashboard design"
+impact: "Calmer operations checks"
+accent: "#2f6f98"
+stack: ["Go", "MQTT", "Hugo"]
+demo: "https://example.org/projects/harbor-watch"
+repo: "https://example.org/repos/harbor-watch"
+---
+
+## Problem
+
+Marina staff had raw sensor feeds for wind, water level, and pump status, but the live dashboard was too noisy for routine checks.
+
+## Approach
+
+Harbor Watch converts raw readings into a static digest with current alerts, recent trends, and a maintenance log. The design avoids dense charts unless the operator needs to inspect a specific event.
+
+## Result
+
+The case study shows how a mostly static interface can make operational data useful without becoming another screen to monitor all day.

--- a/example-site/content/projects/lumen-ledger/hero.svg
+++ b/example-site/content/projects/lumen-ledger/hero.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Lumen Ledger preview</title>
+  <desc id="desc">A household energy journal with meter readings, monthly bars, and notes.</desc>
+  <rect width="1200" height="675" fill="#fbf1ea"/>
+  <rect x="88" y="78" width="1024" height="520" rx="18" fill="#ffffff" stroke="#dfc8b8" stroke-width="3"/>
+  <text x="132" y="132" fill="#79472d" font-family="monospace" font-size="36" font-weight="700">Lumen Ledger</text>
+  <rect x="132" y="178" width="432" height="360" rx="14" fill="#fff8f3" stroke="#dfc8b8" stroke-width="3"/>
+  <text x="166" y="230" fill="#a8623d" font-family="monospace" font-size="24" font-weight="700">Monthly use</text>
+  <rect x="180" y="430" width="42" height="58" rx="5" fill="#d9a17f"/>
+  <rect x="252" y="384" width="42" height="104" rx="5" fill="#a8623d"/>
+  <rect x="324" y="342" width="42" height="146" rx="5" fill="#d9a17f"/>
+  <rect x="396" y="306" width="42" height="182" rx="5" fill="#a8623d"/>
+  <rect x="468" y="364" width="42" height="124" rx="5" fill="#d9a17f"/>
+  <rect x="612" y="178" width="456" height="160" rx="14" fill="#fff8f3" stroke="#dfc8b8" stroke-width="3"/>
+  <text x="646" y="230" fill="#a8623d" font-family="monospace" font-size="24" font-weight="700">Notes</text>
+  <rect x="646" y="266" width="314" height="14" rx="7" fill="#a8623d"/>
+  <rect x="646" y="300" width="240" height="14" rx="7" fill="#d9a17f"/>
+  <rect x="612" y="378" width="456" height="160" rx="14" fill="#fff8f3" stroke="#dfc8b8" stroke-width="3"/>
+  <text x="646" y="430" fill="#a8623d" font-family="monospace" font-size="24" font-weight="700">Reading</text>
+  <rect x="646" y="466" width="180" height="18" rx="9" fill="#a8623d"/>
+  <rect x="646" y="502" width="286" height="14" rx="7" fill="#d9a17f"/>
+</svg>

--- a/example-site/content/projects/lumen-ledger/index.md
+++ b/example-site/content/projects/lumen-ledger/index.md
@@ -1,0 +1,31 @@
+---
+title: "Lumen Ledger"
+date: 2024-04-18T09:00:00Z
+draft: false
+weight: 50
+summary: "A privacy-first household energy journal that turns meter readings into monthly patterns and practical notes."
+subtitle: "A household energy journal built around private notes."
+heroImage: "hero.svg"
+heroAlt: "Journal preview for Lumen Ledger showing household energy readings and monthly notes."
+year: 2024
+projectType: "Private journal"
+status: "Archived"
+role: "Full build"
+impact: "Energy patterns in context"
+accent: "#a8623d"
+stack: ["Hugo", "Charts CSS", "YAML"]
+demo: "https://example.org/projects/lumen-ledger"
+repo: "https://example.org/repos/lumen-ledger"
+---
+
+## Problem
+
+Household energy apps usually optimize for supplier dashboards, not for personal notes about weather, equipment changes, or behavior shifts.
+
+## Approach
+
+Lumen Ledger keeps readings in plain YAML, then renders monthly summaries with notes beside each change. The site can be generated locally and shared as a static archive if needed.
+
+## Result
+
+The project demonstrates a small, privacy-first reporting pattern: enough structure to find trends, but simple enough to keep using after the initial interest fades.

--- a/example-site/content/projects/orbit-planner/hero.svg
+++ b/example-site/content/projects/orbit-planner/hero.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Orbit Planner preview</title>
+  <desc id="desc">A release calendar with launch milestones and review checkpoints.</desc>
+  <rect width="1200" height="675" fill="#eef2fb"/>
+  <rect x="90" y="76" width="1020" height="520" rx="18" fill="#fff" stroke="#c7d1e8" stroke-width="3"/>
+  <text x="136" y="132" fill="#314f86" font-family="monospace" font-size="36" font-weight="700">Orbit Planner</text>
+  <rect x="136" y="180" width="928" height="72" rx="12" fill="#e7edfb"/>
+  <rect x="136" y="290" width="210" height="210" rx="12" fill="#f8faff" stroke="#c7d1e8" stroke-width="3"/>
+  <rect x="376" y="290" width="210" height="210" rx="12" fill="#f8faff" stroke="#c7d1e8" stroke-width="3"/>
+  <rect x="616" y="290" width="210" height="210" rx="12" fill="#f8faff" stroke="#c7d1e8" stroke-width="3"/>
+  <rect x="856" y="290" width="210" height="210" rx="12" fill="#f8faff" stroke="#c7d1e8" stroke-width="3"/>
+  <circle cx="240" cy="386" r="38" fill="#4b6fb4"/>
+  <circle cx="480" cy="386" r="38" fill="#7893cc"/>
+  <circle cx="720" cy="386" r="38" fill="#4b6fb4"/>
+  <circle cx="960" cy="386" r="38" fill="#7893cc"/>
+  <path d="M278 386h164m76 0h164m76 0h164" stroke="#aebce0" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/example-site/content/projects/orbit-planner/index.md
+++ b/example-site/content/projects/orbit-planner/index.md
@@ -1,0 +1,27 @@
+---
+title: "Orbit Planner"
+date: 2023-12-04T09:00:00Z
+draft: false
+weight: 60
+summary: "A lightweight launch calendar for small teams coordinating releases, reviews, and dependency checks."
+subtitle: "A release planning calendar for small product teams."
+heroImage: "hero.svg"
+heroAlt: "Calendar preview for Orbit Planner showing launch milestones and review checkpoints."
+year: 2023
+status: "Archived"
+role: "Planning system"
+---
+
+## Problem
+
+Release work was scattered across calendar events, pull requests, and private notes. The team needed one small place to see what was blocked and what was ready.
+
+## Approach
+
+Orbit Planner keeps each release as a markdown record with milestones, owners, and checklist items.[^records] The generated site groups upcoming work by week.
+
+## Result
+
+The project made launch readiness visible without introducing another project management tool.
+
+[^records]: Release records used the same fields for every launch, which made blocked reviews and missing approvals easier to compare.

--- a/example-site/content/projects/pulse-library/hero.svg
+++ b/example-site/content/projects/pulse-library/hero.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Pulse Library preview</title>
+  <desc id="desc">A component reference library with cards and accessibility notes.</desc>
+  <rect width="1200" height="675" fill="#f3f0f8"/>
+  <rect x="92" y="78" width="1016" height="518" rx="18" fill="#fff" stroke="#d2c8de" stroke-width="3"/>
+  <text x="136" y="132" fill="#5a4776" font-family="monospace" font-size="36" font-weight="700">Pulse Library</text>
+  <rect x="136" y="182" width="286" height="318" rx="14" fill="#fbf9ff" stroke="#d2c8de" stroke-width="3"/>
+  <rect x="456" y="182" width="286" height="318" rx="14" fill="#fbf9ff" stroke="#d2c8de" stroke-width="3"/>
+  <rect x="776" y="182" width="286" height="318" rx="14" fill="#fbf9ff" stroke="#d2c8de" stroke-width="3"/>
+  <rect x="174" y="228" width="184" height="20" rx="10" fill="#735c99"/>
+  <rect x="494" y="228" width="170" height="20" rx="10" fill="#735c99"/>
+  <rect x="814" y="228" width="154" height="20" rx="10" fill="#735c99"/>
+  <rect x="174" y="286" width="210" height="14" rx="7" fill="#c5b6d8"/>
+  <rect x="174" y="324" width="162" height="14" rx="7" fill="#c5b6d8"/>
+  <rect x="494" y="286" width="204" height="14" rx="7" fill="#c5b6d8"/>
+  <rect x="814" y="286" width="188" height="14" rx="7" fill="#c5b6d8"/>
+  <path d="M178 430l34 34 76-90" fill="none" stroke="#4f8a58" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/example-site/content/projects/pulse-library/index.md
+++ b/example-site/content/projects/pulse-library/index.md
@@ -1,0 +1,27 @@
+---
+title: "Pulse Library"
+date: 2023-08-16T09:00:00Z
+draft: false
+weight: 70
+summary: "A small design reference library for teams collecting patterns, component notes, and accessibility checks."
+subtitle: "A design reference library for repeatable interface patterns."
+heroImage: "hero.svg"
+heroAlt: "Library preview for Pulse Library showing component cards and accessibility notes."
+year: 2023
+status: "Live"
+role: "Design documentation"
+---
+
+## Problem
+
+Design decisions were repeated from memory, which made similar components drift across product surfaces.
+
+## Approach
+
+Pulse Library collects examples, usage notes, and accessibility checks as ordinary markdown pages. The index groups patterns by task instead of component name.[^task-first]
+
+## Result
+
+Teams could compare prior decisions quickly and keep interface patterns consistent without a large design-system process.
+
+[^task-first]: Grouping by task helped contributors find patterns by the work they were doing, such as filtering a list or confirming a destructive action.

--- a/example-site/content/projects/stitch-log/hero.svg
+++ b/example-site/content/projects/stitch-log/hero.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Stitch Log preview</title>
+  <desc id="desc">A repair journal with fabric swatches and repair notes.</desc>
+  <rect width="1200" height="675" fill="#fbf0f4"/>
+  <rect x="92" y="78" width="1016" height="518" rx="18" fill="#fff" stroke="#e1c4d0" stroke-width="3"/>
+  <text x="136" y="132" fill="#844c64" font-family="monospace" font-size="36" font-weight="700">Stitch Log</text>
+  <rect x="136" y="184" width="400" height="328" rx="14" fill="#fff8fa" stroke="#e1c4d0" stroke-width="3"/>
+  <path d="M178 252c52 44 104-44 156 0s104-44 156 0" fill="none" stroke="#b45f82" stroke-width="10" stroke-linecap="round"/>
+  <path d="M178 322c52 44 104-44 156 0s104-44 156 0" fill="none" stroke="#d596ad" stroke-width="10" stroke-linecap="round"/>
+  <path d="M178 392c52 44 104-44 156 0s104-44 156 0" fill="none" stroke="#b45f82" stroke-width="10" stroke-linecap="round"/>
+  <rect x="612" y="184" width="456" height="84" rx="12" fill="#fff8fa" stroke="#e1c4d0" stroke-width="3"/>
+  <rect x="612" y="306" width="456" height="84" rx="12" fill="#fff8fa" stroke="#e1c4d0" stroke-width="3"/>
+  <rect x="612" y="428" width="456" height="84" rx="12" fill="#fff8fa" stroke="#e1c4d0" stroke-width="3"/>
+  <rect x="646" y="216" width="230" height="14" rx="7" fill="#b45f82"/>
+  <rect x="646" y="338" width="280" height="14" rx="7" fill="#b45f82"/>
+  <rect x="646" y="460" width="200" height="14" rx="7" fill="#b45f82"/>
+</svg>

--- a/example-site/content/projects/stitch-log/index.md
+++ b/example-site/content/projects/stitch-log/index.md
@@ -1,0 +1,25 @@
+---
+title: "Stitch Log"
+date: 2023-05-25T09:00:00Z
+draft: false
+weight: 80
+summary: "A repair journal for textile workshops that records materials, faults, fixes, and follow-up care."
+subtitle: "A repair journal for textile workshops."
+heroImage: "hero.svg"
+heroAlt: "Journal preview for Stitch Log showing repair records and fabric swatches."
+year: 2023
+status: "Prototype"
+role: "Information architecture"
+---
+
+## Problem
+
+Repair shops had useful notes about materials and fixes, but those notes were hard to search after an item left the bench.
+
+## Approach
+
+Stitch Log structures each repair as a page with material tags, fault notes, images, and care instructions.
+
+## Result
+
+The prototype created a reusable repair history that could be searched by fabric, technique, or recurring fault.

--- a/example-site/content/projects/summit-schedule/hero.svg
+++ b/example-site/content/projects/summit-schedule/hero.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Summit Schedule preview</title>
+  <desc id="desc">A conference schedule with session blocks arranged by track.</desc>
+  <rect width="1200" height="675" fill="#f4f5ea"/>
+  <rect x="90" y="76" width="1020" height="520" rx="18" fill="#fff" stroke="#d5d7ba" stroke-width="3"/>
+  <text x="136" y="132" fill="#6b6f32" font-family="monospace" font-size="36" font-weight="700">Summit Schedule</text>
+  <rect x="136" y="182" width="930" height="56" rx="10" fill="#e9eccf"/>
+  <rect x="136" y="276" width="270" height="220" rx="12" fill="#fbfcf2" stroke="#d5d7ba" stroke-width="3"/>
+  <rect x="466" y="276" width="270" height="220" rx="12" fill="#fbfcf2" stroke="#d5d7ba" stroke-width="3"/>
+  <rect x="796" y="276" width="270" height="220" rx="12" fill="#fbfcf2" stroke="#d5d7ba" stroke-width="3"/>
+  <rect x="170" y="320" width="178" height="18" rx="9" fill="#8c9141"/>
+  <rect x="500" y="320" width="150" height="18" rx="9" fill="#8c9141"/>
+  <rect x="830" y="320" width="188" height="18" rx="9" fill="#8c9141"/>
+  <rect x="170" y="372" width="200" height="14" rx="7" fill="#c2c77d"/>
+  <rect x="500" y="372" width="190" height="14" rx="7" fill="#c2c77d"/>
+  <rect x="830" y="372" width="156" height="14" rx="7" fill="#c2c77d"/>
+</svg>

--- a/example-site/content/projects/summit-schedule/index.md
+++ b/example-site/content/projects/summit-schedule/index.md
@@ -1,0 +1,25 @@
+---
+title: "Summit Schedule"
+date: 2022-11-10T09:00:00Z
+draft: false
+weight: 90
+summary: "A conference schedule generator that turns session proposals into tracks, speaker pages, and printable agendas."
+subtitle: "A static conference schedule generator."
+heroImage: "hero.svg"
+heroAlt: "Schedule preview for Summit Schedule showing conference tracks and session blocks."
+year: 2022
+status: "Case study"
+role: "Static site build"
+---
+
+## Problem
+
+Small conferences needed a public schedule, printable agenda, and speaker index without managing the same session data in three places.
+
+## Approach
+
+Summit Schedule uses structured markdown for sessions and speakers, then renders track pages and printable views from the same source.
+
+## Result
+
+The case study showed how static generation can cover most event-publishing needs with a maintainable workflow.

--- a/example-site/content/projects/timber-trace/hero.svg
+++ b/example-site/content/projects/timber-trace/hero.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Timber Trace preview</title>
+  <desc id="desc">A provenance dashboard for timber batches and supplier records.</desc>
+  <rect width="1200" height="675" fill="#f7efe7"/>
+  <rect x="92" y="78" width="1016" height="518" rx="18" fill="#fff" stroke="#dfc7ad" stroke-width="3"/>
+  <text x="136" y="132" fill="#754f2c" font-family="monospace" font-size="36" font-weight="700">Timber Trace</text>
+  <rect x="136" y="184" width="930" height="120" rx="14" fill="#fff8f0" stroke="#dfc7ad" stroke-width="3"/>
+  <path d="M172 244h822" stroke="#b9804a" stroke-width="18" stroke-linecap="round"/>
+  <path d="M212 244c60-44 120 44 180 0s120-44 180 0 120 44 180 0 120-44 180 0" fill="none" stroke="#e0b07f" stroke-width="8" stroke-linecap="round"/>
+  <rect x="136" y="354" width="432" height="118" rx="12" fill="#fff8f0" stroke="#dfc7ad" stroke-width="3"/>
+  <rect x="634" y="354" width="432" height="118" rx="12" fill="#fff8f0" stroke="#dfc7ad" stroke-width="3"/>
+  <rect x="170" y="394" width="250" height="14" rx="7" fill="#b9804a"/>
+  <rect x="668" y="394" width="286" height="14" rx="7" fill="#b9804a"/>
+  <rect x="170" y="432" width="178" height="14" rx="7" fill="#dfc7ad"/>
+  <rect x="668" y="432" width="204" height="14" rx="7" fill="#dfc7ad"/>
+</svg>

--- a/example-site/content/projects/timber-trace/index.md
+++ b/example-site/content/projects/timber-trace/index.md
@@ -1,0 +1,25 @@
+---
+title: "Timber Trace"
+date: 2022-07-14T09:00:00Z
+draft: false
+weight: 100
+summary: "A provenance log for small furniture studios tracking wood batches, suppliers, finishes, and care notes."
+subtitle: "A provenance log for furniture studios."
+heroImage: "hero.svg"
+heroAlt: "Provenance preview for Timber Trace showing supplier records and wood batch notes."
+year: 2022
+status: "Prototype"
+role: "Data model"
+---
+
+## Problem
+
+Furniture studios often keep material provenance in receipts, notebooks, and photos. That makes it hard to answer customer questions later.
+
+## Approach
+
+Timber Trace gives each batch a simple record with supplier, species, finish, project links, and care notes.
+
+## Result
+
+The prototype made provenance easier to preserve and publish alongside finished pieces.

--- a/example-site/content/projects/waveforge-studio/hero.svg
+++ b/example-site/content/projects/waveforge-studio/hero.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Waveforge Studio preview</title>
+  <desc id="desc">An audio sketchbook with waveform tracks and production notes.</desc>
+  <rect width="1200" height="675" fill="#eef6f8"/>
+  <rect x="92" y="78" width="1016" height="518" rx="18" fill="#fff" stroke="#bdd7df" stroke-width="3"/>
+  <text x="136" y="132" fill="#2d6675" font-family="monospace" font-size="36" font-weight="700">Waveforge Studio</text>
+  <rect x="136" y="188" width="930" height="80" rx="12" fill="#f4fbfd" stroke="#bdd7df" stroke-width="3"/>
+  <rect x="136" y="306" width="930" height="80" rx="12" fill="#f4fbfd" stroke="#bdd7df" stroke-width="3"/>
+  <rect x="136" y="424" width="930" height="80" rx="12" fill="#f4fbfd" stroke="#bdd7df" stroke-width="3"/>
+  <path d="M170 228h34l18-28 28 58 28-42 22 20h700" fill="none" stroke="#3b8193" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M170 346h54l20-26 30 52 26-34 24 12h676" fill="none" stroke="#79acba" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M170 464h42l28-42 28 72 26-48 28 18h678" fill="none" stroke="#3b8193" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/example-site/content/projects/waveforge-studio/index.md
+++ b/example-site/content/projects/waveforge-studio/index.md
@@ -1,0 +1,25 @@
+---
+title: "Waveforge Studio"
+date: 2022-03-09T09:00:00Z
+draft: false
+weight: 110
+summary: "An audio sketchbook for producers collecting loops, processing chains, notes, and release candidates."
+subtitle: "An audio sketchbook for producers."
+heroImage: "hero.svg"
+heroAlt: "Audio preview for Waveforge Studio showing waveform tracks and production notes."
+year: 2022
+status: "Archived"
+role: "Prototype build"
+---
+
+## Problem
+
+Audio sketches were easy to lose once they moved between folders, exports, and notes.
+
+## Approach
+
+Waveforge Studio links each sketch to its source files, processing notes, and release status. Static pages make the archive easy to browse.
+
+## Result
+
+The archive helped producers revisit ideas by mood, tempo, and production state.

--- a/example-site/content/projects/yardstick/hero.svg
+++ b/example-site/content/projects/yardstick/hero.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Yardstick preview</title>
+  <desc id="desc">A measurement notebook with experiment metrics and outcome notes.</desc>
+  <rect width="1200" height="675" fill="#f1f5ef"/>
+  <rect x="92" y="78" width="1016" height="518" rx="18" fill="#fff" stroke="#cbdcc4" stroke-width="3"/>
+  <text x="136" y="132" fill="#476b3d" font-family="monospace" font-size="36" font-weight="700">Yardstick</text>
+  <rect x="136" y="190" width="392" height="300" rx="14" fill="#f8fbf6" stroke="#cbdcc4" stroke-width="3"/>
+  <rect x="594" y="190" width="472" height="300" rx="14" fill="#f8fbf6" stroke="#cbdcc4" stroke-width="3"/>
+  <rect x="176" y="402" width="44" height="52" rx="5" fill="#86a878"/>
+  <rect x="250" y="352" width="44" height="102" rx="5" fill="#5f8a50"/>
+  <rect x="324" y="308" width="44" height="146" rx="5" fill="#86a878"/>
+  <rect x="398" y="260" width="44" height="194" rx="5" fill="#5f8a50"/>
+  <rect x="638" y="246" width="318" height="16" rx="8" fill="#5f8a50"/>
+  <rect x="638" y="296" width="256" height="16" rx="8" fill="#a8c59d"/>
+  <rect x="638" y="346" width="362" height="16" rx="8" fill="#a8c59d"/>
+  <path d="M640 430l32 32 74-88" fill="none" stroke="#5f8a50" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/example-site/content/projects/yardstick/index.md
+++ b/example-site/content/projects/yardstick/index.md
@@ -1,0 +1,27 @@
+---
+title: "Yardstick"
+date: 2021-10-28T09:00:00Z
+draft: false
+weight: 120
+summary: "A measurement notebook for tiny experiments, tracking hypotheses, sample sizes, observations, and outcomes."
+subtitle: "A measurement notebook for small experiments."
+heroImage: "hero.svg"
+heroAlt: "Notebook preview for Yardstick showing experiment metrics and outcome notes."
+year: 2021
+status: "Archived"
+role: "Research workflow"
+---
+
+## Problem
+
+Small experiments were easy to start and hard to compare after the fact because notes used different formats.
+
+## Approach
+
+Yardstick gives each experiment a consistent markdown structure for hypothesis, method, observation, and outcome.[^template]
+
+## Result
+
+The notebook made experiments easier to review and helped teams decide which ideas deserved more work.
+
+[^template]: The template was intentionally short so small experiments could be documented in minutes instead of becoming a separate reporting chore.

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+  {{ $projects := .Pages.ByWeight }}
+  {{ $paginator := .Paginate $projects }}
+  <main class="projects-index">
+    <header class="projects-hero">
+      <h1>{{ .Title }}</h1>
+      {{ with .Params.subtitle }}<p class="projects-lede">{{ . }}</p>{{ end }}
+      {{ with .Content }}<div class="content projects-intro">{{ . }}</div>{{ end }}
+    </header>
+
+    {{ if gt (len $paginator.Pages) 0 }}
+      <div class="project-grid">
+        {{ range $paginator.Pages }}
+          {{ $project := . }}
+          {{ $hero := "" }}
+          {{ with $project.Params.heroImage }}
+            {{ $hero = $project.Resources.GetMatch . }}
+          {{ end }}
+          <article class="project-card">
+            <a class="project-card-image" href="{{ .RelPermalink }}" aria-label="Read more about {{ .Title }}">
+              {{ with $hero }}
+                <img src="{{ .RelPermalink }}" alt="{{ $project.Params.heroAlt | default $project.Title }}">
+              {{ else }}
+                <span aria-hidden="true">{{ .Title }}</span>
+              {{ end }}
+            </a>
+            <div class="project-card-body">
+              <h2 class="title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+              <p class="project-excerpt">{{ .Summary | plainify }}</p>
+              <p class="project-more"><a href="{{ .RelPermalink }}">Read more</a></p>
+            </div>
+          </article>
+        {{ end }}
+      </div>
+      {{ partial "pagination.html" . }}
+    {{ end }}
+  </main>
+{{ end }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,0 +1,41 @@
+{{ define "main" }}
+  {{ $hero := "" }}
+  {{ with .Params.heroImage }}
+    {{ $hero = $.Resources.GetMatch . }}
+  {{ end }}
+  {{ $pages := where .Site.RegularPages.ByWeight "Section" "projects" }}
+  <main>
+    <article class="project">
+      {{ with $hero }}
+        <img class="project-hero-image" src="{{ .RelPermalink }}" alt="{{ $.Params.heroAlt | default $.Title }}">
+      {{ end }}
+      <h1 class="title">{{ .Title }}</h1>
+      {{ with .Params.subtitle }}<h3 class="subtitle">{{ . }}</h3>{{ end }}
+      <div class="content">{{ .Content }}</div>
+    </article>
+  </main>
+
+  {{ if ne .Site.Params.post_nav.enabled false }}
+    {{ $showTitle := .Site.Params.post_nav.show_title }}
+    <nav class="post-nav" aria-label="Project navigation">
+      <div class="post-nav-left">
+        {{ with $pages.Next . }}
+          {{ if $showTitle }}
+            <a href="{{ .RelPermalink }}">&#8612; {{ .Title }}</a>
+          {{ else }}
+            <a href="{{ .RelPermalink }}">&#8612; Previous Project</a>
+          {{ end }}
+        {{ end }}
+      </div>
+      <div class="post-nav-right">
+        {{ with $pages.Prev . }}
+          {{ if $showTitle }}
+            <a href="{{ .RelPermalink }}">{{ .Title }} &#8614;</a>
+          {{ else }}
+            <a href="{{ .RelPermalink }}">Next Project &#8614;</a>
+          {{ end }}
+        {{ end }}
+      </div>
+    </nav>
+  {{ end }}
+{{ end }}

--- a/static/css/smigle-lite.css
+++ b/static/css/smigle-lite.css
@@ -193,6 +193,10 @@ article {
   margin-top: 0.75rem;
 }
 
+.section-header .content {
+  margin-top: 1rem;
+}
+
 .content > * + * {
   margin-top: 1.05rem;
 }
@@ -299,6 +303,122 @@ footer {
   align-items: center;
   margin-top: 2rem;
   color: var(--mutedcolor);
+}
+
+.projects-hero {
+  padding: 1rem 0 0;
+}
+
+.projects-hero h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  line-height: 1.15;
+}
+
+.projects-lede {
+  margin: 0.65rem 0 0;
+  color: var(--mutedcolor);
+  font-size: 1.08rem;
+  line-height: 1.45;
+}
+
+.projects-intro {
+  max-width: 64ch;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.1rem;
+  margin-top: 2rem;
+}
+
+.project-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--bordercolor);
+  border-radius: var(--radius);
+  background: var(--bgcolor);
+}
+
+.project-card-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0.9rem;
+}
+
+.project-card .title {
+  margin: 0;
+  font-size: 1.18rem;
+  line-height: 1.25;
+}
+
+.project-card-image {
+  display: block;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-bottom: 1px solid var(--bordercolor);
+  color: var(--mutedcolor);
+  background: var(--codebgcolor);
+  text-decoration: none;
+}
+
+.project-card-image img {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  object-fit: cover;
+}
+
+.project-card-image span {
+  display: grid;
+  height: 100%;
+  place-items: center;
+  padding: 1rem;
+  text-align: center;
+}
+
+.project-excerpt {
+  margin: 0.65rem 0 0;
+  color: var(--mutedcolor);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.project-card-body .project-more {
+  margin-top: auto;
+  padding-top: 0.9rem;
+}
+
+.project-hero-image {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin: 0 0 1.25rem;
+  border: 1px solid var(--bordercolor);
+  border-radius: var(--radius);
+  background: var(--codebgcolor);
+  object-fit: cover;
+}
+
+.project-more {
+  margin: 0.95rem 0 0;
+}
+
+@media (max-width: 720px) {
+  .projects-hero h1 {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 620px) {
+  .project-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 img {


### PR DESCRIPTION
  - Add project archetype and list/single layouts
  - Enable projects in example configs
  - Add example project pages with hero assets
  - Add theme showcase posts and supporting styles